### PR TITLE
Checking bond state on Android.

### DIFF
--- a/android/src/main/java/BleClient.kt
+++ b/android/src/main/java/BleClient.kt
@@ -190,6 +190,8 @@ class BleClient(private val activity: Activity, private val plugin: BleClientPlu
         }
         val settings = ScanSettings.Builder()
             .setCallbackType(ScanSettings.CALLBACK_TYPE_ALL_MATCHES)
+            .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
+            .setLegacy(false)
             .build()
 
         scanCb = object: ScanCallback(){

--- a/android/src/main/java/BleClient.kt
+++ b/android/src/main/java/BleClient.kt
@@ -4,6 +4,7 @@ import Peripheral
 import android.Manifest
 import android.annotation.SuppressLint
 import android.app.Activity
+import android.bluetooth.BluetoothDevice
 import android.bluetooth.BluetoothAdapter
 import android.bluetooth.BluetoothManager
 import android.bluetooth.BluetoothProfile

--- a/android/src/main/java/BleClient.kt
+++ b/android/src/main/java/BleClient.kt
@@ -38,6 +38,7 @@ class BleDevice(
     private val name: String,
     private val rssi: Int,
     private val connected: Boolean,
+    private val bonded: Boolean,
     private val manufacturerData: SparseArray<ByteArray>?,
     private val serviceData: Map<ParcelUuid, ByteArray>?,
     private val services: List<ParcelUuid>?
@@ -50,6 +51,7 @@ class BleDevice(
         obj.put("id",address)
         obj.put("name",name)
         obj.put("connected",connected)
+        obj.put("bonded",bonded)
         obj.put("rssi",rssi)
         // create Json Array from services
         val services = if (services != null) {
@@ -208,11 +210,13 @@ class BleClient(private val activity: Activity, private val plugin: BleClientPlu
                     name = ""
                 }
                 val connected = this@BleClient.manager!!.getConnectionState(result.device,BluetoothProfile.GATT_SERVER) == BluetoothProfile.STATE_CONNECTED
+                val bonded = result.device.getBondState() == BluetoothDevice.BOND_BONDED
                 val device = BleDevice(
                     result.device.address,
                     name,
                     result.rssi,
                     connected,
+                    bonded,
                     result.scanRecord?.manufacturerSpecificData,
                     result.scanRecord?.serviceData,
                     result.scanRecord?.serviceUuids

--- a/android/src/main/java/BleClientPlugin.kt
+++ b/android/src/main/java/BleClientPlugin.kt
@@ -81,7 +81,7 @@ class BleClientPlugin(private val activity: Activity): Plugin(activity) {
     @Command
     fun is_bonded(invoke: Invoke){
         val args = invoke.parseArgs(ConnectParams::class.java)
-        val device = this.connected_devices[args.address]
+        val device = this.devices[args.address]
         val res = JSObject()
         if (device == null){
             res.put("result", false)

--- a/android/src/main/java/BleClientPlugin.kt
+++ b/android/src/main/java/BleClientPlugin.kt
@@ -79,6 +79,19 @@ class BleClientPlugin(private val activity: Activity): Plugin(activity) {
     }
 
     @Command
+    fun is_bonded(invoke: Invoke){
+        val args = invoke.parseArgs(ConnectParams::class.java)
+        val device = this.connected_devices[args.address]
+        val res = JSObject()
+        if (device == null){
+            res.put("result", false)
+        } else {
+            res.put("result", device.isBonded())
+        }
+        invoke.resolve(res)
+    }
+
+    @Command
     fun discover_services(invoke:Invoke){
         val args = invoke.parseArgs(ConnectParams::class.java)
         val device = this.connected_devices[args.address]

--- a/android/src/main/java/Peripheral.kt
+++ b/android/src/main/java/Peripheral.kt
@@ -24,6 +24,7 @@ class Peripheral(private val activity: Activity, private val device: BluetoothDe
     private val base64Encoder: Base64.Encoder = Base64.getEncoder()
 
     private var connected = false
+    private var bonded = false
     private var gatt: BluetoothGatt? = null
     private var services: List<BluetoothGattService> = listOf()
     private val characteristics: MutableMap<UUID,BluetoothGattCharacteristic> = mutableMapOf()

--- a/android/src/main/java/Peripheral.kt
+++ b/android/src/main/java/Peripheral.kt
@@ -223,6 +223,10 @@ class Peripheral(private val activity: Activity, private val device: BluetoothDe
         return this.connected
     }
 
+    fun isBonded(): Boolean {
+        return this.device.bondState == BluetoothDevice.BOND_BONDED
+    }
+
     @SuppressLint("MissingPermission")
     fun disconnect(invoke: Invoke){
         this.gatt?.disconnect()

--- a/guest-js/index.ts
+++ b/guest-js/index.ts
@@ -5,6 +5,7 @@ export type BleDevice = {
   name: string;
   rssi: number;
   isConnected: boolean;
+  isBonded: boolean;
   services: string[];
   manufacturerData: Record<number, Uint8Array>;
   serviceData: Record<string, Uint8Array>;

--- a/src/android.rs
+++ b/src/android.rs
@@ -344,17 +344,17 @@ impl btleplug::api::Peripheral for Peripheral {
         Ok(res.result)
     }
 
-    async fn is_bonded(&self) -> Result<bool> {
-        let res: BoolResult = get_handle()
-            .run_mobile_plugin(
-                "is_bonded",
-                ConnectParams {
-                    address: self.address,
-                },
-            )
-            .map_err(|e| btleplug::Error::RuntimeError(e.to_string()))?;
-        Ok(res.result)
-    }
+    // async fn is_bonded(&self) -> Result<bool> {
+    //     let res: BoolResult = get_handle()
+    //         .run_mobile_plugin(
+    //             "is_bonded",
+    //             ConnectParams {
+    //                 address: self.address,
+    //             },
+    //         )
+    //         .map_err(|e| btleplug::Error::RuntimeError(e.to_string()))?;
+    //     Ok(res.result)
+    // }
 
     async fn connect(&self) -> Result<()> {
         call_plugin_with_timeout(

--- a/src/android.rs
+++ b/src/android.rs
@@ -252,7 +252,7 @@ struct ReadParams {
 }
 
 #[async_trait::async_trait]
-impl btleplug::api::Peripheral for Peripheral {
+impl BondingPeripheral for Peripheral {
     async fn is_bonded(&self) -> Result<bool> {
         let res: BoolResult = get_handle()
             .run_mobile_plugin(

--- a/src/android.rs
+++ b/src/android.rs
@@ -344,6 +344,18 @@ impl btleplug::api::Peripheral for Peripheral {
         Ok(res.result)
     }
 
+    async fn is_bonded(&self) -> Result<bool> {
+        let res: BoolResult = get_handle()
+            .run_mobile_plugin(
+                "is_bonded",
+                ConnectParams {
+                    address: self.address,
+                },
+            )
+            .map_err(|e| btleplug::Error::RuntimeError(e.to_string()))?;
+        Ok(res.result)
+    }
+
     async fn connect(&self) -> Result<()> {
         call_plugin_with_timeout(
             "connect",

--- a/src/android.rs
+++ b/src/android.rs
@@ -27,7 +27,7 @@ use tokio_stream::wrappers::ReceiverStream;
 use tracing::{debug, info};
 use uuid::Uuid;
 
-use crate::models;
+use crate::models::BondingPeripheral;
 
 type Result<T> = std::result::Result<T, btleplug::Error>;
 

--- a/src/android.rs
+++ b/src/android.rs
@@ -27,7 +27,7 @@ use tokio_stream::wrappers::ReceiverStream;
 use tracing::{debug, info};
 use uuid::Uuid;
 
-mod models;
+use crate::models;
 
 type Result<T> = std::result::Result<T, btleplug::Error>;
 

--- a/src/android.rs
+++ b/src/android.rs
@@ -27,6 +27,8 @@ use tokio_stream::wrappers::ReceiverStream;
 use tracing::{debug, info};
 use uuid::Uuid;
 
+mod models;
+
 type Result<T> = std::result::Result<T, btleplug::Error>;
 
 static HANDLE: OnceCell<PluginHandle<Wry>> = OnceCell::new();
@@ -251,7 +253,7 @@ struct ReadParams {
 
 #[allow(dependency_on_unit_never_type_fallback)]
 #[async_trait::async_trait]
-impl btleplug::api::Peripheral for Peripheral {
+impl BondingPeripheral for Peripheral {
     fn id(&self) -> PeripheralId {
         self.id.clone()
     }

--- a/src/android.rs
+++ b/src/android.rs
@@ -253,7 +253,7 @@ struct ReadParams {
 
 #[allow(dependency_on_unit_never_type_fallback)]
 #[async_trait::async_trait]
-impl BondingPeripheral for Peripheral {
+impl BondingPeripheral + btleplug::api::Peripheral for Peripheral {
     fn id(&self) -> PeripheralId {
         self.id.clone()
     }

--- a/src/android.rs
+++ b/src/android.rs
@@ -253,7 +253,7 @@ struct ReadParams {
 
 #[allow(dependency_on_unit_never_type_fallback)]
 #[async_trait::async_trait]
-impl BondingPeripheral + btleplug::api::Peripheral for Peripheral {
+impl BondingPeripheral for Peripheral {
     fn id(&self) -> PeripheralId {
         self.id.clone()
     }

--- a/src/android.rs
+++ b/src/android.rs
@@ -343,18 +343,17 @@ impl btleplug::api::Peripheral for Peripheral {
             .map_err(|e| btleplug::Error::RuntimeError(e.to_string()))?;
         Ok(res.result)
     }
-
-    // async fn is_bonded(&self) -> Result<bool> {
-    //     let res: BoolResult = get_handle()
-    //         .run_mobile_plugin(
-    //             "is_bonded",
-    //             ConnectParams {
-    //                 address: self.address,
-    //             },
-    //         )
-    //         .map_err(|e| btleplug::Error::RuntimeError(e.to_string()))?;
-    //     Ok(res.result)
-    // }
+    async fn is_bonded(&self) -> Result<bool> {
+        let res: BoolResult = get_handle()
+            .run_mobile_plugin(
+                "is_bonded",
+                ConnectParams {
+                    address: self.address,
+                },
+            )
+            .map_err(|e| btleplug::Error::RuntimeError(e.to_string()))?;
+        Ok(res.result)
+    }
 
     async fn connect(&self) -> Result<()> {
         call_plugin_with_timeout(

--- a/src/android.rs
+++ b/src/android.rs
@@ -251,9 +251,23 @@ struct ReadParams {
     characteristic: Uuid,
 }
 
+#[async_trait::async_trait]
+impl btleplug::api::Peripheral for Peripheral {
+    async fn is_bonded(&self) -> Result<bool> {
+        let res: BoolResult = get_handle()
+            .run_mobile_plugin(
+                "is_bonded",
+                ConnectParams {
+                    address: self.address,
+                },
+            )
+            .map_err(|e| btleplug::Error::RuntimeError(e.to_string()))?;
+        Ok(res.result)
+    }
+}
 #[allow(dependency_on_unit_never_type_fallback)]
 #[async_trait::async_trait]
-impl BondingPeripheral for Peripheral {
+impl btleplug::api::Peripheral for Peripheral {
     fn id(&self) -> PeripheralId {
         self.id.clone()
     }
@@ -338,17 +352,6 @@ impl BondingPeripheral for Peripheral {
         let res: BoolResult = get_handle()
             .run_mobile_plugin(
                 "is_connected",
-                ConnectParams {
-                    address: self.address,
-                },
-            )
-            .map_err(|e| btleplug::Error::RuntimeError(e.to_string()))?;
-        Ok(res.result)
-    }
-    async fn is_bonded(&self) -> Result<bool> {
-        let res: BoolResult = get_handle()
-            .run_mobile_plugin(
-                "is_bonded",
                 ConnectParams {
                     address: self.address,
                 },

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -279,7 +279,8 @@ impl Handler {
         debug!("starting service discovery");
         device.discover_services().await?;
         debug!("service discovery done");
-        let mut services = device.services();
+        let services = device.services();
+        println!("{:?}", services);
         for s in services {
             for c in &s.characteristics {
                 state.characs.push(c.clone());

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -276,13 +276,10 @@ impl Handler {
     async fn connect_services(&self, state: &mut HandlerState) -> Result<(), Error> {
         let device = self.connected_dev.lock().await;
         let device = device.as_ref().ok_or(Error::NoDeviceConnected)?;
+        debug!("starting service discovery");
+        device.discover_services().await?;
+        debug!("service discovery done");
         let mut services = device.services();
-        if services.is_empty() {
-            debug!("starting service discovery");
-            device.discover_services().await?;
-            debug!("service discovery done");
-            services = device.services();
-        }
         for s in services {
             for c in &s.characteristics {
                 state.characs.push(c.clone());

--- a/src/models.rs
+++ b/src/models.rs
@@ -50,6 +50,7 @@ pub trait BondingPeripheral: btleplug::api::Peripheral {
 }
 
 // Default implementation for btleplug
+#[cfg(not(target_os = "android"))]
 impl<P: btleplug::api::Peripheral> BondingPeripheral for P {}
 
 impl BleDevice {

--- a/src/models.rs
+++ b/src/models.rs
@@ -60,7 +60,8 @@ impl BleDevice {
             services: properties.services,
             rssi: properties.rssi,
             is_connected: peripheral.is_connected().await?,
-            is_bonded: false,
+            is_bonded: true,
+            // is_bonded: peripheral.is_bonded().await?,
         })
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -40,10 +40,25 @@ impl PartialEq for BleDevice {
     }
 }
 
+#[cfg(target_os = "android")]
+use crate::android::{Adapter, Manager, Peripheral};
+#[cfg(not(target_os = "android"))]
+use btleplug::platform::{Adapter, Manager, Peripheral};
+
 #[async_trait::async_trait]
-trait BondingPeripheral: btleplug::api::Peripheral {
-    async fn is_bonded(&self) -> Result<bool> {}
+pub trait BondingPeripheral: btleplug::api::Peripheral {
+    async fn is_bonded(&self) -> Result<bool, btleplug::Error> {
+        Ok(false) // Default implementation returns false
+    }
 }
+
+// Blanket implementation for all Peripheral types
+impl<P: btleplug::api::Peripheral> BondingPeripheral for P {}
+
+// #[async_trait::async_trait]
+// trait BondingPeripheral: btleplug::api::Peripheral {
+//     async fn is_bonded(&self) -> Result<bool> {}
+// }
 
 impl BleDevice {
     pub(crate) async fn from_peripheral<P: BondingPeripheral>(

--- a/src/models.rs
+++ b/src/models.rs
@@ -40,19 +40,16 @@ impl PartialEq for BleDevice {
     }
 }
 
-// #[cfg(target_os = "android")]
-// use crate::android::{Adapter, Manager, Peripheral};
-// #[cfg(not(target_os = "android"))]
-// use btleplug::platform::{Adapter, Manager, Peripheral};
-
 #[async_trait::async_trait]
 pub trait BondingPeripheral: btleplug::api::Peripheral {
     async fn is_bonded(&self) -> Result<bool, btleplug::Error> {
-        Ok(false) // Default implementation returns false
+        Err(btleplug::Error::NotSupported(
+            "Bonding is not implemented in btleplug".to_string(),
+        ))
     }
 }
 
-// Blanket implementation for all Peripheral types
+// Default implementation for btleplug
 impl<P: btleplug::api::Peripheral> BondingPeripheral for P {}
 
 impl BleDevice {

--- a/src/models.rs
+++ b/src/models.rs
@@ -13,6 +13,7 @@ pub struct BleDevice {
     pub address: String,
     pub name: String,
     pub is_connected: bool,
+    pub is_bonded: bool,
     pub manufacturer_data: HashMap<u16, Vec<u8>>,
     pub service_data: HashMap<Uuid, Vec<u8>>,
     pub services: Vec<Uuid>,
@@ -59,6 +60,7 @@ impl BleDevice {
             services: properties.services,
             rssi: properties.rssi,
             is_connected: peripheral.is_connected().await?,
+            is_bonded: false,
         })
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -40,10 +40,10 @@ impl PartialEq for BleDevice {
     }
 }
 
-#[cfg(target_os = "android")]
-use crate::android::{Adapter, Manager, Peripheral};
-#[cfg(not(target_os = "android"))]
-use btleplug::platform::{Adapter, Manager, Peripheral};
+// #[cfg(target_os = "android")]
+// use crate::android::{Adapter, Manager, Peripheral};
+// #[cfg(not(target_os = "android"))]
+// use btleplug::platform::{Adapter, Manager, Peripheral};
 
 #[async_trait::async_trait]
 pub trait BondingPeripheral: btleplug::api::Peripheral {
@@ -54,11 +54,6 @@ pub trait BondingPeripheral: btleplug::api::Peripheral {
 
 // Blanket implementation for all Peripheral types
 impl<P: btleplug::api::Peripheral> BondingPeripheral for P {}
-
-// #[async_trait::async_trait]
-// trait BondingPeripheral: btleplug::api::Peripheral {
-//     async fn is_bonded(&self) -> Result<bool> {}
-// }
 
 impl BleDevice {
     pub(crate) async fn from_peripheral<P: BondingPeripheral>(

--- a/src/models.rs
+++ b/src/models.rs
@@ -40,8 +40,13 @@ impl PartialEq for BleDevice {
     }
 }
 
+#[async_trait::async_trait]
+trait BondingPeripheral: btleplug::api::Peripheral {
+    async fn is_bonded(&self) -> Result<bool> {}
+}
+
 impl BleDevice {
-    pub(crate) async fn from_peripheral<P: btleplug::api::Peripheral>(
+    pub(crate) async fn from_peripheral<P: BondingPeripheral>(
         peripheral: &P,
     ) -> Result<Self, error::Error> {
         #[cfg(target_vendor = "apple")]
@@ -60,8 +65,8 @@ impl BleDevice {
             services: properties.services,
             rssi: properties.rssi,
             is_connected: peripheral.is_connected().await?,
-            is_bonded: true,
-            // is_bonded: peripheral.is_bonded().await?,
+            // is_bonded: true,
+            is_bonded: peripheral.is_bonded().await?,
         })
     }
 }


### PR DESCRIPTION
This PR adds checking if a peripheral has been previously bonded. Sadly, only on android since [btleplug](https://github.com/deviceplug/btleplug) doesn't have any bonding API whatsoever.
[bluest](https://github.com/alexmoon/bluest) seems to feature the bonding operation but that's a whole different crate than the one you're using.