### PR TITLE
Fix: Use actual characteristic properties in ResCharacteristic

### DIFF
--- a/android/src/main/java/Peripheral.kt
+++ b/android/src/main/java/Peripheral.kt
@@ -280,7 +280,7 @@ class Peripheral(private val activity: Activity, private val device: BluetoothDe
             for (charac in service.characteristics){
                 characs.add(ResCharacteristic(
                     charac.uuid.toString(),
-                    0,
+                    charac.properties,
                     charac.descriptors.map { desc ->  desc.uuid.toString()},
                 ))
             }


### PR DESCRIPTION
## Problem

The @mnlphlp/plugin-blec library has a bug on Android where it hardcodes 
`BleCharacteristic.properties` to `0` in the `Peripheral.kt` implementation:

```kotlin
characs.add(ResCharacteristic(
    charac.uuid.toString(),
    0,  // ← BUG: hardcoded to 0 instead of charac.properties
    charac.descriptors.map { desc -> desc.uuid.toString()},
))
```

This causes all characteristics to show "NO OPS" (no supported operations)
on Android devices, even though they actually support Read, Write, Notify, etc.

Desktop/Windows works fine because it uses a different implementation.

So I changed it and then it works!

```kotlin
characs.add(ResCharacteristic(
    charac.uuid.toString(),
    charac.properties, // It works.
    charac.descriptors.map { desc ->  desc.uuid.toString()},
))
```

## My First Solution In Frontend (Some Notes)

Before I found this bug in library, I just...

Implemented an automatic property inference mechanism that:

1. Detects when all characteristic properties are 0 (Android bug indicator)
2. Infers the actual properties based on:
    - CCCD descriptors (0x2902) → Notify capability
    - SCCD descriptors (0x2903) → Indicate capability
    - Standard BLE UUIDs → Device Name (0x2a00), Model Number (0x2a24), etc.
    - Heuristics → If no descriptors, assume Read/Write/WriteNoResp
3. Restores the properties to correct bitmask values:
    - 0x02 = Read
    - 0x04 = WriteWithoutResponse
    - 0x08 = Write
    - 0x10 = Notify
    - 0x20 = Indicate

