### PR TITLE
fix(android): notify channel is never fired on android 12 and below

### DIFF
--- a/android/src/main/java/Peripheral.kt
+++ b/android/src/main/java/Peripheral.kt
@@ -94,8 +94,31 @@ class Peripheral(private val activity: Activity, private val device: BluetoothDe
             }
         }
 
+        // Android 13 and upper
         override fun onCharacteristicChanged(
             gatt: BluetoothGatt,
+            characteristic: BluetoothGattCharacteristic,
+            value: ByteArray
+        ) {
+            handleCharacteristicChanged(characteristic, value)
+        }
+
+        // Android 12 and below
+        @Suppress("OVERRIDE_DEPRECATION")
+        override fun onCharacteristicChanged(
+            gatt: BluetoothGatt,
+            characteristic: BluetoothGattCharacteristic
+        ) {
+            val value = characteristic.value
+            if (value != null) {
+                handleCharacteristicChanged(characteristic, value)
+            } else {
+                Log.e("Peripheral", "Value received onCharacteristicChanged is null")
+            }
+        }
+
+        // Extract the common logic into a helper function
+        private fun handleCharacteristicChanged(
             characteristic: BluetoothGattCharacteristic,
             value: ByteArray
         ) {


### PR DESCRIPTION
Implemented deprecated onCharacteristicChanged in Peripheral.kt.

The code only implemented onCharacteristicChanged for API level 33+, but Android 12 and below use API level 32 and below. This meant notificationChannel wasn't sending anything, because phone never called onCharacteristicChanged.

Solution: Override the deprecated onCharacteristicChanged method to support API level < 33.

Tested on Android 12 and 13 phones.
