### PR TITLE
Lazy init central

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -159,7 +159,29 @@ impl Handler {
 
         let central = get_central().await?;
         let arc_adapter = Arc::new(central);
+
+        if let Ok(handler_static) = crate::get_handler() {
+            let stream_res = handler_static
+                .get_event_stream_internal(arc_adapter.clone())
+                .await;
+            tauri::async_runtime::spawn(async move {
+                if let Ok(mut stream) = stream_res {
+                    while let Some(event) = stream.next().await {
+                        let _ = handler_static.handle_event(event).await;
+                    }
+                }
+            });
+        }
+
         Ok(arc_adapter)
+    }
+
+    async fn get_event_stream_internal(
+        &self,
+        adapter: Arc<Adapter>,
+    ) -> Result<Pin<Box<dyn Stream<Item = CentralEvent> + Send>>, Error> {
+        let events = adapter.events().await?;
+        Ok(events)
     }
 
     /// Returns true if a device is connected
@@ -814,7 +836,14 @@ impl Handler {
     }
 
     pub async fn get_adapter_state(&self) -> AdapterState {
-        let adapter = self.get_or_init_adapter().await?;
+        let adapter = match self.get_or_init_adapter().await {
+            Ok(a) => a,
+            Err(e) => {
+                error!("Failed to init adapter for state check: {e}");
+                return AdapterState::Unknown;
+            }
+        };
+
         match adapter.adapter_state().await {
             Ok(state) => match state {
                 CentralState::Unknown => AdapterState::Unknown,

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -54,7 +54,7 @@ impl HandlerState {
 
 pub struct Handler {
     devices: Arc<Mutex<HashMap<String, Peripheral>>>,
-    adapter: Arc<Adapter>,
+    adapter: Mutex<Option<Arc<Adapter>>>,
     notify_listeners: Arc<Mutex<Vec<Listener>>>,
     connected_rx: watch::Receiver<bool>,
     connected_tx: watch::Sender<bool>,
@@ -132,11 +132,10 @@ impl<F: Fn(Vec<u8>) + Send + Sync + 'static> From<F> for SubscriptionHandler {
 
 impl Handler {
     pub(crate) async fn new() -> Result<Self, Error> {
-        let central = get_central().await?;
         let (connected_tx, connected_rx) = watch::channel(false);
         Ok(Self {
             devices: Arc::new(Mutex::new(HashMap::new())),
-            adapter: Arc::new(central),
+            adapter: Mutex::new(None),
             notify_listeners: Arc::new(Mutex::new(vec![])),
             connected_rx,
             connected_tx,
@@ -150,6 +149,17 @@ impl Handler {
                 characs: vec![],
             }),
         })
+    }
+
+    async fn get_or_init_adapter(&self) -> Result<Arc<Adapter>, Error> {
+        let mut adapter_guard = self.adapter.lock().await;
+        if let Some(adapter) = &*adapter_guard {
+            return Ok(adapter.clone());
+        }
+
+        let central = get_central().await?;
+        let arc_adapter = Arc::new(central);
+        Ok(arc_adapter)
     }
 
     /// Returns true if a device is connected
@@ -437,23 +447,24 @@ impl Handler {
                 return Err(Error::InvalidFilterMask);
             }
         }
+        let adapter = self.get_or_init_adapter().await?;
         {
             let mut state = self.state.lock().await;
             // stop any ongoing scan
             if let Some(handle) = state.scan_task.take() {
                 handle.abort();
-                self.adapter.stop_scan().await?;
+                adapter.stop_scan().await?;
             }
             // start a new scan
             *ALLOW_IBEACONS.lock().await = allow_ibeacons;
-            self.adapter
+            adapter
                 .start_scan(btleplug::api::ScanFilter::default())
                 .await?;
         }
         self.send_scan_update(true).await;
         let mut state = self.state.lock().await;
         let mut self_devices = self.devices.clone();
-        let adapter = self.adapter.clone();
+        let adapter = adapter.clone();
         state.scan_task = Some(tokio::task::spawn(async move {
             self_devices.lock().await.clear();
             let loops = timeout / 200;
@@ -546,7 +557,8 @@ impl Handler {
     /// # Errors
     /// Returns an error if stopping the scan fails
     pub async fn stop_scan(&self) -> Result<(), Error> {
-        self.adapter.stop_scan().await?;
+        let adapter = self.get_or_init_adapter().await?;
+        adapter.stop_scan().await?;
         if let Some(handle) = self.state.lock().await.scan_task.take() {
             handle.abort();
         }
@@ -727,7 +739,8 @@ impl Handler {
     pub(super) async fn get_event_stream(
         &self,
     ) -> Result<Pin<Box<dyn Stream<Item = CentralEvent> + Send>>, Error> {
-        let events = self.adapter.events().await?;
+        let adapter = self.get_or_init_adapter().await?;
+        let events = adapter.events().await?;
         Ok(events)
     }
 
@@ -801,7 +814,8 @@ impl Handler {
     }
 
     pub async fn get_adapter_state(&self) -> AdapterState {
-        match self.adapter.adapter_state().await {
+        let adapter = self.get_or_init_adapter().await?;
+        match adapter.adapter_state().await {
             Ok(state) => match state {
                 CentralState::Unknown => AdapterState::Unknown,
                 CentralState::PoweredOn => AdapterState::On,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,6 @@ pub fn try_init() -> Result<TauriPlugin<Wry>, Error> {
         .setup(|app, api| {
             #[cfg(target_os = "android")]
             android::init(app, api)?;
-            async_runtime::spawn(handle_events());
             Ok(())
         })
         .build();
@@ -67,20 +66,4 @@ pub fn check_permissions(ask_if_denied: bool) -> Result<bool, Error> {
     return Ok(android::check_permissions(ask_if_denied)?);
     #[cfg(not(target_os = "android"))]
     return Ok(true);
-}
-
-async fn handle_events() {
-    let handler = get_handler().expect("failed to get handler");
-    let stream = handler
-        .get_event_stream()
-        .await
-        .expect("failed to get event stream");
-    stream
-        .for_each(|event| async {
-            handler
-                .handle_event(event)
-                .await
-                .expect("failed to handle event");
-        })
-        .await;
 }


### PR DESCRIPTION
On macOS/iOS, instantiating the Bluetooth Central Manager immediately triggers
the system authorization popup. When called at startup, this caused a deadlock:
the main thread blocked to wait for user input while the UI was still
initializing, resulting in a frozen 'black screen' with the popup hidden behind it.