### PR TITLE
Fix BLE scanning on Linux: cache adapter and best-effort stop

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -473,10 +473,11 @@ impl Handler {
         let adapter = self.get_or_init_adapter().await?;
         {
             let mut state = self.state.lock().await;
-            // stop any ongoing scan
+            // stop any ongoing scan (best-effort — scan may have already
+            // been stopped by the polling task)
             if let Some(handle) = state.scan_task.take() {
                 handle.abort();
-                adapter.stop_scan().await?;
+                let _ = adapter.stop_scan().await;
             }
             // start a new scan
             *ALLOW_IBEACONS.lock().await = allow_ibeacons;

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -173,6 +173,7 @@ impl Handler {
             });
         }
 
+        *adapter_guard = Some(arc_adapter.clone());
         Ok(arc_adapter)
     }
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -579,13 +579,15 @@ impl Handler {
 
     /// Stops scanning for devices
     /// # Errors
-    /// Returns an error if stopping the scan fails
+    /// Stops an ongoing scan. The polling task is aborted first, then the
+    /// adapter scan is stopped (best-effort — it may have already been
+    /// stopped by the polling task finishing).
     pub async fn stop_scan(&self) -> Result<(), Error> {
-        let adapter = self.get_or_init_adapter().await?;
-        adapter.stop_scan().await?;
         if let Some(handle) = self.state.lock().await.scan_task.take() {
             handle.abort();
         }
+        let adapter = self.get_or_init_adapter().await?;
+        let _ = adapter.stop_scan().await;
         self.send_scan_update(false).await;
         Ok(())
     }


### PR DESCRIPTION
## Summary

Three related fixes for BLE scanning issues on Linux (BlueZ):

1. **Store adapter after lazy initialization** — `get_or_init_adapter()` created a new adapter on every call but never cached it. Each adapter had a different D-Bus connection, so `stop_scan` from a different connection than `start_scan` failed with "No discovery started" on Linux. macOS/Windows were unaffected as their BLE stacks are lenient about this.

2. **Best-effort stop_scan in discover() cleanup** — When restarting a scan, the previous scan's polling task may have already stopped the adapter. The cleanup `stop_scan` is therefore redundant and fails on Linux. Made best-effort with `let _ =`.

3. **Abort scan task before stop_scan in stop_scan()** — If `adapter.stop_scan()` errored, the task abort was never reached (early return via `?`). The polling task kept running and blocked subsequent operations. Now the task is aborted first, then the adapter stop is best-effort.

## Context

Discovered while developing a Tauri BLE application targeting Linux, macOS and Windows. All three issues are caused by BlueZ being stricter than CoreBluetooth/WinRT about D-Bus client identity and redundant stop calls.

## Testing

Tested on Linux (BlueZ), macOS (CoreBluetooth) and Windows (WinRT). Scanning starts, stops, restarts and connects correctly on all three platforms.