### PR TITLE
fix(android): don't drop scanned devices when is_bonded() fails

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -74,8 +74,14 @@ impl BleDevice {
             services: properties.services,
             rssi: properties.rssi,
             is_connected: peripheral.is_connected().await?,
+            // On Android `is_bonded()` performs a per-device plugin IPC call. During a
+            // scan this runs for every discovered peripheral, and if it errors (e.g. the
+            // `is_bonded` command isn't available) the `?` propagated the failure, causing
+            // `Handler::add_devices` to drop the *entire* device — so a scan silently
+            // returned no results. A failure to read bond state must not exclude the
+            // device from scan results, so default to `false` instead of propagating.
             #[cfg(target_os = "android")]
-            is_bonded: peripheral.is_bonded().await?,
+            is_bonded: peripheral.is_bonded().await.unwrap_or(false),
             #[cfg(not(target_os = "android"))]
             is_bonded: false,
             tx_power_level: properties.tx_power_level,


### PR DESCRIPTION
On Android, `BleDevice::from_peripheral` calls `peripheral.is_bonded().await?` for **every** peripheral during a scan (via `Handler::add_devices`). `is_bonded()` performs a per-device plugin IPC call, and if it errors the `?` propagates, so `add_devices` drops the **entire** device.

The net effect is that `scan()` returns **no devices at all** even though peripherals were discovered — the JS `onDevices` handler never fires and the app cannot find/connect to any device.

I hit this on a real device (Android 14, Tauri 2, plugin 0.12): the scanner saw the peripheral at the stack level, `on_device_callback` populated `DEVICES`, `adapter.peripherals()` returned them, but `add_devices` returned an empty list. Instrumenting `from_peripheral` showed every call failing with:

```
Btleplug error: Runtime Error: No command is_bonded found for plugin com.plugin.blec.BleClientPlugin
```

A failure to read bond state should not exclude a device from scan results. This changes the Android branch to default to `false` on error instead of propagating:

```rust
is_bonded: peripheral.is_bonded().await.unwrap_or(false),
```

After this change scanning works reliably again (devices are delivered, connect succeeds). The bond flag is also already available from the scan record on the Kotlin side, so a follow-up could avoid the per-device IPC entirely, but this minimal fix restores scanning without behaviour change on the happy path.