### PR TITLE
fix(commands): intermittent BLE send crash

### DIFF
--- a/src/commands.rs
+++ b/src/commands.rs
@@ -171,7 +171,7 @@ async fn subscribe_channel(
     service: Option<Uuid>,
 ) -> Result<mpsc::Receiver<Vec<u8>>> {
     let handler = get_handler()?;
-    let (tx, rx) = tokio::sync::mpsc::channel(1);
+    let (tx, rx) = tokio::sync::mpsc::channel(512);
     handler
         .subscribe(characteristic, service, move |data: Vec<u8>| {
             info!("subscribe_channel: {:?}", data);


### PR DESCRIPTION

### Problem

After connecting to a BLE device and sending data, the application can intermittently crash with the following error:

``
failed to send data to the channel: "Full(..)" | ...commands.rs:179:18
``

The crash occurs in `subscribe_channel` because the channel is created with a capacity of `1`, while the subscription callback uses `try_send`. If a new BLE notification arrives before the previous value is consumed, `try_send` returns `Full` and the `expect` call panics.

### Change

- Increase the `tokio::sync::mpsc::channel` capacity in `subscribe_channel` from `1` to `512`.

This reduces the likelihood of `try_send` returning `Full` during normal BLE notification bursts.

### Related Issue

- Fixes #56